### PR TITLE
build: Update to CMake 3.27 with native CUDA support

### DIFF
--- a/src/source/CMakeLists.txt
+++ b/src/source/CMakeLists.txt
@@ -2,9 +2,10 @@
 # DualSPHysics GPU/CPU v5.2.245 12-09-2022
 #==================================================================
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.27)
+cmake_policy(SET CMP0146 NEW) # CUDA Support
 
-PROJECT(DualSPHysics)
+PROJECT(DualSPHysics LANGUAGES CXX CUDA)
 
 #------------------------------------------------------------------
 # Coupling options
@@ -42,26 +43,9 @@ set(OBMDBC JPartNormalData.cpp)
 #------------------------------------------------------------------
 # NVCC Flags
 #------------------------------------------------------------------
-find_package(CUDA QUIET)
 
-if(CUDA_FOUND)
-  if(CUDA_VERSION VERSION_LESS "7.5")
-    message("Using cuda version <7.5")
-    list(APPEND CUDA_NVCC_FLAGS "-use_fast_math -O3 -gencode=arch=compute_20,code=\"sm_20,compute_20\"")
-  elseif(CUDA_VERSION VERSION_GREATER "7.4" AND CUDA_VERSION VERSION_LESS "9.1")
-    message("Using cuda version >=7.5 and <9.1")
-    list(APPEND CUDA_NVCC_FLAGS "-use_fast_math -O3  -gencode=arch=compute_20,code=\"sm_20,compute_20\" -gencode=arch=compute_30,code=\"sm_30,compute_30\" -gencode=arch=compute_35,code=\"sm_35,compute_35\" -gencode=arch=compute_37,code=\"sm_37,compute_37\" -gencode=arch=compute_50,code=\"sm_50,compute_50\" -gencode=arch=compute_52,code=\"sm_52,compute_52\"")
-  elseif(CUDA_VERSION VERSION_GREATER "9.1" AND CUDA_VERSION VERSION_LESS "11.0")
-  message("Using cuda version >=9.1 and <11.0")
-    list(APPEND CUDA_NVCC_FLAGS "-use_fast_math -O3  -gencode=arch=compute_30,code=\"sm_30,compute_30\" -gencode=arch=compute_35,code=\"sm_35,compute_35\" -gencode=arch=compute_37,code=\"sm_37,compute_37\" -gencode=arch=compute_50,code=\"sm_50,compute_50\" -gencode=arch=compute_52,code=\"sm_52,compute_52\" -gencode=arch=compute_61,code=\"sm_61,compute_61\" -gencode=arch=compute_70,code=\"sm_70,compute_70\"")
-  else()
-    message("Using cuda version >=11.0")
-	list(APPEND CUDA_NVCC_FLAGS "-Wno-deprecated-gpu-targets") # disable warning for the deprecated sm_35 and sm_37
-    list(APPEND CUDA_NVCC_FLAGS "-use_fast_math -O3 -gencode=arch=compute_35,code=\"sm_35,compute_35\" -gencode=arch=compute_37,code=\"sm_37,compute_37\" -gencode=arch=compute_50,code=\"sm_50,compute_50\" -gencode=arch=compute_52,code=\"sm_52,compute_52\" -gencode=arch=compute_61,code=\"sm_61,compute_61\" -gencode=arch=compute_70,code=\"sm_70,compute_70\"")
-  endif()
-else()
-  message("CUDA Libraries were not found.")
-endif()
+list(APPEND CUDA_NVCC_FLAGS "-Wno-deprecated-gpu-targets")
+list(APPEND CUDA_NVCC_FLAGS "-use_fast_math -O3 -arch=all-major")
 
 #------------------------------------------------------------------
 # Static libraries linker path
@@ -98,17 +82,15 @@ set (CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})    
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   add_executable(DualSPHysics5.2CPU_linux64 ${OBJXML} ${OBJSPHMOTION} ${OBCOMMON} ${OBCOMMONDSPH} ${OBSPH} ${OBSPHSINGLE} ${OBWAVERZ} ${OBCHRONO} ${OBMOORDYN} ${OBINOUT} ${OBMDBC})
   install(TARGETS	DualSPHysics5.2CPU_linux64 DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
-  if (CUDA_FOUND)
-    cuda_add_executable(DualSPHysics5.2_linux64 ${OBJXML} ${OBJSPHMOTION} ${OBCOMMON} ${OBCOMMONDSPH} ${OBSPH} ${OBSPHSINGLE} ${OBCOMMONGPU} ${OBSPHGPU} ${OBSPHSINGLEGPU} ${OBCUDA} ${OBWAVERZ} ${OBWAVERZCUDA} ${OBCHRONO} ${OBMOORDYN} ${OBINOUT} ${OBINOUTGPU} ${OBMDBC})
-    install(TARGETS DualSPHysics5.2_linux64 DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
-  endif(CUDA_FOUND)
-elseif(MSVC) 
+
+  add_executable(DualSPHysics5.2_linux64 ${OBJXML} ${OBJSPHMOTION} ${OBCOMMON} ${OBCOMMONDSPH} ${OBSPH} ${OBSPHSINGLE} ${OBCOMMONGPU} ${OBSPHGPU} ${OBSPHSINGLEGPU} ${OBCUDA} ${OBWAVERZ} ${OBWAVERZCUDA} ${OBCHRONO} ${OBMOORDYN} ${OBINOUT} ${OBINOUTGPU} ${OBMDBC})
+  install(TARGETS DualSPHysics5.2_linux64 DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+elseif(MSVC)
   add_executable(DualSPHysics5.2CPU_win64 ${OBJXML} ${OBJSPHMOTION} ${OBCOMMON} ${OBCOMMONDSPH} ${OBSPH} ${OBSPHSINGLE} ${OBWAVERZ} ${OBCHRONO} ${OBMOORDYN} ${OBINOUT} ${OBMDBC})
   install(TARGETS	DualSPHysics5.2CPU_win64 DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
-  if (CUDA_FOUND)
-    cuda_add_executable(DualSPHysics5.2_win64 ${OBJXML} ${OBJSPHMOTION} ${OBCOMMON} ${OBCOMMONDSPH} ${OBSPH} ${OBSPHSINGLE} ${OBCOMMONGPU} ${OBSPHGPU} ${OBSPHSINGLEGPU} ${OBCUDA} ${OBWAVERZ} ${OBWAVERZCUDA} ${OBCHRONO} ${OBMOORDYN} ${OBINOUT} ${OBINOUTGPU} ${OBMDBC})
-    install(TARGETS DualSPHysics5.2_win64 DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
-  endif(CUDA_FOUND)
+
+  add_executable(DualSPHysics5.2_win64 ${OBJXML} ${OBJSPHMOTION} ${OBCOMMON} ${OBCOMMONDSPH} ${OBSPH} ${OBSPHSINGLE} ${OBCOMMONGPU} ${OBSPHGPU} ${OBSPHSINGLEGPU} ${OBCUDA} ${OBWAVERZ} ${OBWAVERZCUDA} ${OBCHRONO} ${OBMOORDYN} ${OBINOUT} ${OBINOUTGPU} ${OBMDBC})
+  install(TARGETS DualSPHysics5.2_win64 DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 endif()
 
 foreach(OUTPUTCONFIG ${CMAKE_CONFIGURATION_TYPES} )
@@ -122,7 +104,7 @@ endforeach(OUTPUTCONFIG CMAKE_CONFIGURATION_TYPES )
 set(LINKER_FLAGS "")
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   set(LINKER_FLAGS ${LINKER_FLAGS} jvtklib_64 jwavegen_64 jnumexlib_64)
-elseif(MSVC) 
+elseif(MSVC)
   set(LINKER_FLAGS ${LINKER_FLAGS} LibJVtkLib_x64_v143_Release LibJWaveGen_x64_v143_Release LibJNumexLib_x64_v143_Release)
 endif()
 
@@ -134,7 +116,7 @@ if(ENABLE_MOORDYN)
   message(STATUS "Using MoorDyn+")
   if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     set(LINKER_FLAGS ${LINKER_FLAGS} dsphmoordyn_64)
-  elseif(MSVC) 
+  elseif(MSVC)
     set(LINKER_FLAGS ${LINKER_FLAGS} LibDSphMoorDyn_x64_v143_Release)
   endif()
 else()
@@ -147,7 +129,7 @@ if(ENABLE_CHRONO)
   message(STATUS "Using ChronoEngine Module")
   if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     set(LINKER_FLAGS ${LINKER_FLAGS} ChronoEngine dsphchrono)
-  elseif(MSVC) 
+  elseif(MSVC)
     set(LINKER_FLAGS ${LINKER_FLAGS} dsphchrono)
   endif()
 else()
@@ -160,13 +142,10 @@ endif(ENABLE_CHRONO)
 #------------------------------------------------------------------
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   target_link_libraries(DualSPHysics5.2CPU_linux64 ${LINKER_FLAGS})
-  set_target_properties(DualSPHysics5.2CPU_linux64 PROPERTIES COMPILE_FLAGS "-use_fast_math -O3 -fPIC -std=c++0x")
-  
-  if (CUDA_FOUND)
-    target_link_libraries(DualSPHysics5.2_linux64 ${LINKER_FLAGS})
-    set_target_properties(DualSPHysics5.2_linux64 PROPERTIES COMPILE_FLAGS "-use_fast_math -O3 -D_WITHGPU -fPIC -std=c++0x -Wno-deprecated-gpu-targets")
-  endif(CUDA_FOUND)
-  
+  set_target_properties(DualSPHysics5.2CPU_linux64 PROPERTIES COMPILE_FLAGS "-use_fast_math -O3 -fPIC -std=c++14")
+
+  target_link_libraries(DualSPHysics5.2_linux64 ${LINKER_FLAGS})
+  set_target_properties(DualSPHysics5.2_linux64 PROPERTIES COMPILE_FLAGS "-use_fast_math -O3 -D_WITHGPU -fPIC -std=c++14 -Wno-deprecated-gpu-targets")
 elseif(MSVC)
   set_target_properties(DualSPHysics5.2_win64 PROPERTIES COMPILE_FLAGS "/D _WITHGPU")
 
@@ -175,9 +154,9 @@ elseif(MSVC)
     target_link_libraries(DualSPHysics5.2CPU_win64  ${LINKER_FLAGS})
     target_link_libraries(DualSPHysics5.2_win64 ${LINKER_FLAGS})
   #endif()
-  
+
   SET(CUDA_PROPAGATE_HOST_FLAGS OFF CACHE BOOL "Propagate C/CXX Flags and friends to the host compiler in NVCC via -Xompile  " FORCE)
-  
+
   foreach(CPP_FLAGS CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
     if(${CPP_FLAGS} MATCHES "/MD")
       string(REGEX REPLACE "/MD" "/MT" ${CPP_FLAGS} "${${CPP_FLAGS}}")


### PR DESCRIPTION
Hello,

Thank you for developing DualSPHysics!

I update the `CMakeLists.txt` to be able to build the project locally with the recently added native support for CUDA.

Note that this currently:
 - only makes adaptation for Linux
 - assumes that CUDA is always present
 - builds for all major versions of the real architectures 